### PR TITLE
Sync java-upgrade plugin from source repo

### DIFF
--- a/plugins/modernize-java/.github/plugin/plugin.json
+++ b/plugins/modernize-java/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "modernize-java",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AI-powered Java modernization and upgrade assistant. Helps upgrade Java and Spring Boot applications to the latest versions.",
   "author": {
     "name": "Microsoft"


### PR DESCRIPTION
Automated sync of java-upgrade plugin from devdiv-azure-service-dmitryr/azure-java-migration-copilot-vscode-extension. Source: c04e2f1b8c95832ca3ab118c04f20227854b0d9f from xiading/java-upgrade-plugin. Triggered by xiading_microsoft.