### PR TITLE
Sync java-upgrade plugin from source repo

### DIFF
--- a/plugins/modernize-java/.github/plugin/plugin.json
+++ b/plugins/modernize-java/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "modernize-java",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AI-powered Java modernization and upgrade assistant. Helps upgrade Java and Spring Boot applications to the latest versions.",
   "author": {
     "name": "Microsoft"
@@ -12,5 +12,16 @@
     "migration",
     "spring-boot"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "agents": "agents/",
+  "mcpServers": {
+    "appmod-mcp-server": {
+      "type": "local",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@microsoft/github-copilot-app-modernization-mcp-server"
+      ]
+    }
+  }
 }

--- a/plugins/modernize-java/agents/modernize-java.agent.md
+++ b/plugins/modernize-java/agents/modernize-java.agent.md
@@ -2,34 +2,6 @@
 name: 'modernize-java'
 description: 'Upgrades Java projects to target versions (e.g., Java 21, Spring Boot 3.2) via incremental planning and execution. Use this agent for all Java upgrade requests.'
 model: Claude Sonnet 4.6
-tools:
-  - edit
-  - search
-  - runCommands
-  - problems
-  - changes
-  - fetch
-  - todos
-  - askQuestions
-  - read_file
-  - create_file
-  - insert_edit_into_file
-  - replace_string_in_file
-  - file_search
-  - apply_patch
-  - grep_search
-  - semantic_search
-  - list_dir
-  - run_in_terminal
-  - get_terminal_output
-  - get_errors
-  - open_file
-mcp-servers:
-  app-modernization:
-    type: 'local'
-    command: 'npx'
-    args: ['-y', '@microsoft/github-copilot-app-modernization-mcp-server']
-    tools: ['*']
 argument-hint: 'Target versions (e.g., Java 21, Spring Boot 3.2) and project context.'
 handoffs:
     - label: Fix CVEs


### PR DESCRIPTION
Automated sync of java-upgrade plugin from devdiv-azure-service-dmitryr/azure-java-migration-copilot-vscode-extension. Source: 8d7473114ec6e95d08b9d8c27b98ea4ee448e022 from feat/issue-5144. Triggered by haital_microsoft.